### PR TITLE
MAE-59317: Fix vulnerability in dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@types/jest": "^27.0.2",
     "@types/jquery": "^3.5.6",
     "@typescript-eslint/parser": "^4.31.2",
+    "ansi-regex": "~>5.0.1",
     "babel-loader": "^8.2.2",
     "babel-plugin-dynamic-import-node": "^2.3.3",
     "babel-plugin-macros": "^3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1588,6 +1588,11 @@ ansi-regex@^5.0.0:
   resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz"
   integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
 
+ansi-regex@~>5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
+  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
+
 ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz"


### PR DESCRIPTION
## Change description

ansi-regex (version 5.0.0) was flagged as being in a version range containing a vulnerability (> 2.1.1 < 5.0.1).

Upgraded package.json to ~> 5.0.1 and reinstalled to set version to 5.0.1.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Checklists

### Development

- [x] Type checking passes locally
- [x] Tests pass locally

### Security

- [x] Security impact of change has been considered
