### PR TITLE
MAE-59317 follow-up: Rm bad ansi-regex version from lockfile.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "@types/jest": "^27.0.2",
     "@types/jquery": "^3.5.6",
     "@typescript-eslint/parser": "^4.31.2",
-    "ansi-regex": "~>5.0.1",
     "babel-loader": "^8.2.2",
     "babel-plugin-dynamic-import-node": "^2.3.3",
     "babel-plugin-macros": "^3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1584,11 +1584,6 @@ ansi-escapes@^4.2.1:
     type-fest "^0.21.3"
 
 ansi-regex@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz"
-  integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
-
-ansi-regex@~>5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==


### PR DESCRIPTION
Also rm ansi-regex from package.json: not needed.

These changes are related to
https://vistahl.atlassian.net/browse/MAE-59317.

## Change description

This is a follow-up to the PR for https://vistahl.atlassian.net/browse/MAE-59317. The insecure ansi-regex version is still in the lockfile, so this change is to remove it (while keeping the good version).

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Checklists

### Development

- [x] Type checking passes locally
- [x] Tests pass locally

### Security

- [x] Security impact of change has been considered
