### PR TITLE
npm-vulnerabilities: Resolve Minimist to ^1.2.6.

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "jquery": "^3.6.0"
   },
   "resolutions": {
+    "minimist": "^1.2.6",
     "terser": "^5.14.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3458,10 +3458,10 @@ minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.2.0, minimist@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
-  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
+  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
 ms@2.1.2:
   version "2.1.2"


### PR DESCRIPTION
JIRA link: https://vistahl.atlassian.net/browse/MAE-62366

Related PRs
- https://github.com/vhl/m3/pull/9674
- https://github.com/vhl/music/pull/1578

Screenshots
NA