### PR TITLE
npm vulnerability: Upgrade loader-utils to ^1.4.2.

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "jquery": "^3.6.0"
   },
   "resolutions": {
+    "loader-utils": "^1.4.2",
     "minimist": "^1.2.6",
     "terser": "^5.14.2"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3354,10 +3354,10 @@ loader-runner@^4.2.0:
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-4.2.0.tgz#d7022380d66d14c5fb1d496b89864ebcfd478384"
   integrity sha512-92+huvxMvYlMzMt0iIOukcwYBFpkYJdpl2xsZ7LrlayO7E8SOv+JJUEK17B/dJIHAOLMfh2dZZ/Y18WgmGtYNw==
 
-loader-utils@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.0.tgz#c579b5e34cb34b1a74edc6c1fb36bfa371d5a613"
-  integrity sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==
+loader-utils@^1.4.0, loader-utils@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.2.tgz#29a957f3a63973883eb684f10ffd3d151fec01a3"
+  integrity sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==
   dependencies:
     big.js "^5.2.2"
     emojis-list "^3.0.0"


### PR DESCRIPTION
## Change description

Upgrades loader-utils to ^1.4.2 to address a vulnerability.

## Type of change
- [x] Dependency upgrade
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Type checking passes locally
- [x] Tests pass locally
- [x] Application changes have been tested thoroughly

### Security

- [x] Security impact of change has been considered
